### PR TITLE
Hide token for demos and public presentations

### DIFF
--- a/my_app/utils/commons.py
+++ b/my_app/utils/commons.py
@@ -85,7 +85,7 @@ def hf_login_flow():
     if not hf_auth_token:
         hf_auth_token = st.sidebar.text_input(
             "Hugging Face [User Access Tokens](https://huggingface.co/settings/tokens)",
-            os.environ.get("HF_AUTH_TOKEN", ""),
+            os.environ.get("HF_AUTH_TOKEN", ""), type="password"
         )
     if not hf_auth_token:
         st.error(


### PR DESCRIPTION
This is untested @davidberenstein1957 only when you have time, hiding the content of the token field would be useful for demos and presentations